### PR TITLE
Upgrade to detekt 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.ozsie</groupId>
     <artifactId>detekt-maven-plugin</artifactId>
-    <version>1.1.1</version>
+    <version>1.4.0</version>
     <packaging>maven-plugin</packaging>
 
     <name>detekt-maven-plugin Maven Plugin</name>
@@ -40,7 +40,7 @@
 
         <!-- Compile -->
         <kotlin.version>1.3.50</kotlin.version>
-        <detekt.version>1.1.1</detekt.version>
+        <detekt.version>1.4.0</detekt.version>
         <jcommander.version>1.72</jcommander.version>
         <snakeyaml.version>1.21</snakeyaml.version>
         <maven.api.version>3.6.2</maven.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,19 @@
         <detekt-maven-plugin.version>1.0.0</detekt-maven-plugin.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>jcenter</id>
+            <url>https://jcenter.bintray.com/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jcenter</id>
+            <url>https://jcenter.bintray.com/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
The constructor of `io.gitlab.arturbosch.detekt.cli.runners.Runner` changed: two parameters where added. Despite the default values for the new parameters, simply setting the plugin dependency to detekt 1.4.0 does not work. It results in a `java.lang.NoSuchMethodError`.  (The most recent compatible version in 1.2.x.) Compiling against 1.4.0 and releasing the plugin again would fix this.

I matched the plugin version to that of detekt hoping that is least confusing...