### PR TITLE
Bump detekt-version to 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A maven plugin that wraps the Detekt CLI. It supports the same parameters as the
         <plugin>
             <groupId>com.github.ozsie</groupId>
             <artifactId>detekt-maven-plugin</artifactId>
-            <version>1.7.0</version>
+            <version>1.8.0</version>
             <executions>
                 <execution>
                     <phase>verify</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.ozsie</groupId>
     <artifactId>detekt-maven-plugin</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <packaging>maven-plugin</packaging>
 
     <name>detekt-maven-plugin Maven Plugin</name>
@@ -40,7 +40,7 @@
 
         <!-- Compile -->
         <kotlin.version>1.3.61</kotlin.version>
-        <detekt.version>1.7.0</detekt.version>
+        <detekt.version>1.8.0</detekt.version>
         <jcommander.version>1.72</jcommander.version>
         <snakeyaml.version>1.21</snakeyaml.version>
         <maven.api.version>3.6.2</maven.api.version>

--- a/src/main/java/com/github/ozsie/CheckMojo.kt
+++ b/src/main/java/com/github/ozsie/CheckMojo.kt
@@ -12,14 +12,18 @@ import java.nio.file.Paths
 @Suppress("unused")
 @Mojo(name = "check",
         defaultPhase = LifecyclePhase.VERIFY,
+        threadSafe = true,
         requiresDependencyCollection = ResolutionScope.TEST)
 class CheckMojo : DetektMojo() {
     override fun execute() {
         getCliSting().forEach {
             log.debug("Applying $it")
         }
-        val cliArgs = parseArguments<CliArgs>(getCliSting().log().toTypedArray())
+        val cliArgs = parseArguments<CliArgs>(getCliSting().log().toTypedArray(), System.out, System.err)
         skip = !Files.isDirectory(Paths.get(input))
-        if (!skip) return Runner(cliArgs).execute() else log.info("Input directory '$input' not found, skipping module")
+        if (!skip)
+            return Runner(cliArgs, System.out, System.err).execute()
+        else
+            log.info("Input directory '$input' not found, skipping module")
     }
 }

--- a/src/main/java/com/github/ozsie/CreateBaselineMojo.kt
+++ b/src/main/java/com/github/ozsie/CreateBaselineMojo.kt
@@ -13,8 +13,8 @@ open class CreateBaselineMojo : DetektMojo() {
         cliStr.forEach {
             log.debug("Applying $it")
         }
-        val cliArgs = parseArguments<CliArgs>(cliStr)
-        if (!skip) Runner(cliArgs).execute()
+        val cliArgs = parseArguments<CliArgs>(cliStr, System.out, System.err)
+        if (!skip) Runner(cliArgs, System.out, System.err).execute()
     }
     private val cliString get() = getCliSting().apply {
         add(CREATE_BASELINE)

--- a/src/main/java/com/github/ozsie/GenerateConfigMojo.kt
+++ b/src/main/java/com/github/ozsie/GenerateConfigMojo.kt
@@ -9,7 +9,7 @@ import org.apache.maven.plugins.annotations.Mojo
 @Mojo(name = "generate-config")
 open class GenerateConfigMojo : DetektMojo() {
     override fun execute() {
-        val cliArgs = parseArguments<CliArgs>(getCliSting().log().toTypedArray())
+        val cliArgs = parseArguments<CliArgs>(getCliSting().log().toTypedArray(), System.out, System.err)
         ConfigExporter(cliArgs).run {
             if (!skip) return execute()
         }

--- a/src/test/java/com/github/ozsie/CheckMojoSpec.kt
+++ b/src/test/java/com/github/ozsie/CheckMojoSpec.kt
@@ -21,7 +21,6 @@ class CheckMojoSpec : Spek({
     given("a CheckMojo and 'skip' is false") {
         val checkMojo = CheckMojo()
         checkMojo.skip = false
-        checkMojo.input = "."
         on("checkMojo.execute()") {
             test("Unit is expected") {
                 expect(Unit) {


### PR DESCRIPTION
bump version to 1.8.0, and marked "check" as thread-safe

closes https://github.com/Ozsie/detekt-maven-plugin/issues/42
closes https://github.com/Ozsie/detekt-maven-plugin/issues/34


