### PR TITLE
support remote config file

### DIFF
--- a/src/main/java/com/github/ozsie/ResolveConfig.kt
+++ b/src/main/java/com/github/ozsie/ResolveConfig.kt
@@ -8,7 +8,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 
-const val EXPORTED_FILE_LOCATION = "/remote_detekt_config.yml"
+const val EXPORTED_FILE_LOCATION = "/remote-detekt-config.yml"
 
 internal fun resolveConfig(project: MavenProject?, config: String): String {
     if (project == null) return config

--- a/src/main/java/com/github/ozsie/ResolveConfig.kt
+++ b/src/main/java/com/github/ozsie/ResolveConfig.kt
@@ -3,11 +3,26 @@ package com.github.ozsie
 import org.apache.maven.project.MavenProject
 import java.io.File
 import java.io.FileNotFoundException
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+
+const val EXPORTED_FILE_LOCATION = "/remote_detekt_config.yml"
 
 internal fun resolveConfig(project: MavenProject?, config: String): String {
     if (project == null) return config
+    if (config.startsWith("http")) {
+        return getFileFromUrl(project, config)
+    }
     return config.split(',', ';')
         .joinToString(separator = ";") { resolveSingle(project, it) }
+}
+
+private fun getFileFromUrl(project: MavenProject, urlString: String) : String {
+    val url = URL(urlString)
+    url.openStream().use { Files.copy(it, Paths.get(project.basedir.absolutePath + EXPORTED_FILE_LOCATION), StandardCopyOption.REPLACE_EXISTING) }
+    return File(EXPORTED_FILE_LOCATION).absolutePath
 }
 
 private fun resolveSingle(project: MavenProject, config: String): String {

--- a/src/test/java/com/github/ozsie/ResolveConfigSpec.kt
+++ b/src/test/java/com/github/ozsie/ResolveConfigSpec.kt
@@ -11,6 +11,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
+const val REMOTE_REPO = "https://raw.githubusercontent.com/yonbav/detekt-maven-plugin/master"
+const val REMOTE_CONFIG_URL =
+    "$REMOTE_REPO/src/test/resources/resolve-config/remote/remote-config.yml"
 // Note: while annoying, the use of File() in the asserts should maximize cross-platform compatibility
 object ResolveConfigSpec : Spek({
 
@@ -107,18 +110,18 @@ object ResolveConfigSpec : Spek({
         val project = projectWithBasedirAt("resolve-config")
 
         given("remote file exists") {
-            val config = "https://raw.githubusercontent.com/yonbav/detekt-maven-plugin/master/src/test/resources/resolve-config/remote/remote-config.yml"
             on("resolveConfig") {
-                val result = resolveConfig(project, config)
+                val result = resolveConfig(project, REMOTE_CONFIG_URL)
+                val expected = project.basedir.absolutePath + EXPORTED_FILE_LOCATION
                 test("resolves the remote file") {
-                    assertEquals(EXPORTED_FILE_LOCATION, result)
+                    assertEquals(expected, result)
                     assertTrue(Files.exists(Paths.get(project.basedir.absolutePath + EXPORTED_FILE_LOCATION)))
                 }
             }
         }
 
         given("remote file does not exist") {
-            val config = "https://raw.githubusercontent.com/yonbav/detekt-maven-plugin/master/src/test/resources/resolve-config/remote/not-exist-config.yml"
+            val config = "$REMOTE_REPO/does-not-exist.yml"
             on("resolveConfig") {
                 val exception = assertFailsWith<FileNotFoundException> {
                     resolveConfig(project, config)

--- a/src/test/java/com/github/ozsie/ResolveConfigSpec.kt
+++ b/src/test/java/com/github/ozsie/ResolveConfigSpec.kt
@@ -5,8 +5,11 @@ import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.on
 import java.io.File
 import java.io.FileNotFoundException
+import java.nio.file.Files
+import java.nio.file.Paths
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 // Note: while annoying, the use of File() in the asserts should maximize cross-platform compatibility
 object ResolveConfigSpec : Spek({
@@ -95,6 +98,33 @@ object ResolveConfigSpec : Spek({
                         "${File(parentDir, "one.yml")};${File(basedir, "three.yml")}",
                         result
                     )
+                }
+            }
+        }
+    }
+
+    given("remote config file") {
+        val project = projectWithBasedirAt("resolve-config")
+
+        given("remote file exists") {
+            val config = "https://artifactory.example.com/detket/detekt-with-complexity-report.yml"
+            on("resolveConfig") {
+                val result = resolveConfig(project, config)
+                test("resolves the remote file") {
+                    assertEquals(EXPORTED_FILE_LOCATION, result)
+                    assertTrue(Files.exists(Paths.get(project.basedir.absolutePath + EXPORTED_FILE_LOCATION)))
+                }
+            }
+        }
+
+        given("remote file does not exist") {
+            val config = "https://artifactory.example.com/detket/detekt-with-complexity-report-2.yml"
+            on("resolveConfig") {
+                val exception = assertFailsWith<FileNotFoundException> {
+                    resolveConfig(project, config)
+                }
+                test("resolves the remote file") {
+                    assertEquals(config, exception.message)
                 }
             }
         }

--- a/src/test/java/com/github/ozsie/ResolveConfigSpec.kt
+++ b/src/test/java/com/github/ozsie/ResolveConfigSpec.kt
@@ -107,7 +107,7 @@ object ResolveConfigSpec : Spek({
         val project = projectWithBasedirAt("resolve-config")
 
         given("remote file exists") {
-            val config = "https://artifactory.example.com/detket/detekt-with-complexity-report.yml"
+            val config = "https://raw.githubusercontent.com/yonbav/detekt-maven-plugin/master/src/test/resources/resolve-config/remote/remote-config.yml"
             on("resolveConfig") {
                 val result = resolveConfig(project, config)
                 test("resolves the remote file") {
@@ -118,7 +118,7 @@ object ResolveConfigSpec : Spek({
         }
 
         given("remote file does not exist") {
-            val config = "https://artifactory.example.com/detket/detekt-with-complexity-report-2.yml"
+            val config = "https://raw.githubusercontent.com/yonbav/detekt-maven-plugin/master/src/test/resources/resolve-config/remote/not-exist-config.yml"
             on("resolveConfig") {
                 val exception = assertFailsWith<FileNotFoundException> {
                     resolveConfig(project, config)

--- a/src/test/resources/resolve-config/remote/remote-config.yml
+++ b/src/test/resources/resolve-config/remote/remote-config.yml
@@ -1,0 +1,52 @@
+build:
+  maxIssues: 0
+  excludeCorrectable: false
+  weights:
+
+config:
+  validation: true
+  warningsAsErrors: false
+  excludes: ''
+
+processors:
+  active: true
+  exclude:
+    - 'DetektProgressListener'
+
+console-reports:
+  active: true
+  exclude:
+    - 'ProjectStatisticsReport'
+    - 'ComplexityReport'
+    - 'NotificationReport'
+    # - 'FindingsReport'
+    # - 'CodeComplexityReport'
+    - 'FileBasedFindingsReport'
+    - 'LiteFindingsReport'
+
+output-reports:
+  active: true
+  exclude:
+    - 'XmlOutputReport'
+    - 'HtmlOutputReport'
+    - 'SarifOutputReport'
+    - 'TxtOutputReport'
+
+complexity:
+  active: true
+  ComplexMethod:
+    active: true
+    threshold: 0
+    ignoreSingleWhenExpression: false
+    ignoreSimpleWhenEntries: false
+    ignoreNestingFunctions: false
+    nestingFunctions:
+      - 'also'
+      - 'apply'
+      - 'forEach'
+      - 'isNotNull'
+      - 'ifNull'
+      - 'let'
+      - 'run'
+      - 'use'
+      - 'with'


### PR DESCRIPTION
Added support for a remote config file.
 If the config starts with http we will import the file into a local file called 
"remote-detekt-config.yml" and use it as the config file for detekt