### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 A maven plugin that wraps the Detekt CLI. It supports the same parameters as the Detekt CLI.
 
 ## How to use
-### Basic configuration
+See [below](#goals) how to execute after configuring.
+
+### Basic usage
 ```xml
 <build>
     <plugins>
@@ -27,12 +29,38 @@ A maven plugin that wraps the Detekt CLI. It supports the same parameters as the
     </plugins>
 </build>
 ```
-Using the above configuration, Detekt will scan source files in _${basedir}/src_ and output the results in _${basedir}/detekt_.
+Using the above configuration Detekt will scan source files in `${basedir}/src` and output the results in `${basedir}/detekt`.  
 
-All parameters available to Detekt version _1.22.0_ can be configured in
-the plugin.
+## Configuration
+All parameters available to Detekt version _1.22.0_ can be configured in the plugin.
 
-### Remote configuration
+### Local rule configuration
+The plugin supports local files as configuration to be passed to Detekt.
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>com.github.ozsie</groupId>
+            <artifactId>detekt-maven-plugin</artifactId>
+            <version>1.22.0</version>
+            <executions>
+                <execution>
+                    <phase>verify</phase>
+                    <goals><goal>check</goal></goals>
+                    <configuration>
+                        <plugins>
+                            <config>config/detekt/detekt.yml</config>
+                        </plugins>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+```
+Multiple files can be listed with `;` as separator.
+
+### Remote rule configuration
 The plugin supports remote config over http and https.
 ```xml
 <build>
@@ -57,31 +85,11 @@ The plugin supports remote config over http and https.
 </build>
 ```
 
-### Using plugin
-```xml
-<build>
-    <plugins>
-        <plugin>
-            <groupId>com.github.ozsie</groupId>
-            <artifactId>detekt-maven-plugin</artifactId>
-            <version>1.22.0</version>
-            <executions>
-                <execution>
-                    <phase>verify</phase>
-                    <goals><goal>check</goal></goals>
-                    <configuration>
-                        <plugins>
-                            <plugin>path/to/plugin.jar</plugin>
-                        </plugins>
-                    </configuration>
-                </execution>
-            </executions>
-        </plugin>
-    </plugins>
-</build>
-```
+### Using extensions
+Detekt supports [rulesets, processors, reports, etc.](https://detekt.dev/docs/introduction/extensions) packaged in Detekt plugins.
 
-Or
+#### Using published Detekt plugins
+See [Detekt Marketplace](https://detekt.dev/marketplace) for list of known plugins.
 
 ```xml
 <build>
@@ -97,10 +105,12 @@ Or
                 </execution>
             </executions>
             <dependencies>
+                <!-- Detekt's first-party unbundled plugin for library authors:
+                     https://detekt.dev/docs/next/rules/libraries -->
                 <dependency>
-                    <groupId>group</groupId>
-                    <artifactId>artifact</artifactId>
-                    <version>version</version>
+                    <groupId>io.gitlab.arturbosch.detekt</groupId>
+                    <artifactId>detekt-rules-libraries</artifactId>
+                    <version>1.22.0</version>
                 </dependency>
             </dependencies>
         </plugin>
@@ -108,7 +118,33 @@ Or
 </build>
 ```
 
-## Specify report files
+#### Local Detekt plugins
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>com.github.ozsie</groupId>
+            <artifactId>detekt-maven-plugin</artifactId>
+            <version>1.22.0</version>
+            <executions>
+                <execution>
+                    <phase>verify</phase>
+                    <goals><goal>check</goal></goals>
+                    <configuration>
+                        <plugins>
+                            <plugin>local/path/to/plugin.jar</plugin>
+                        </plugins>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+```
+
+### Reporting
+See [Detekt documentation](https://detekt.dev/docs/introduction/reporting) for supported report types.
+
 ```xml
 <build>
     <plugins>
@@ -132,10 +168,9 @@ Or
     </plugins>
 </build>
 ```
-Alternatively, the configuration can be placed outside of the
-`<executions>`. This allows the configuration be used when running goals
-standalone
 
+Alternatively, the configuration can be placed outside of the `<executions>`.
+This allows the configuration be used when running goals standalone.
 ```xml
 <build>
     <plugins>
@@ -159,13 +194,13 @@ standalone
     </plugins>
 </build>
 ```
-## Set baseline
-First a baseline file needs to be generated
+
+### Baseline
+First a [baseline file](https://detekt.dev/docs/introduction/baseline) needs to be generated:
 ```bash
 mvn detekt:cb
 ```
 This will generate a baseline file for each module named as `baseline-<module-name>.xml`. For more information on generating baselines, see [create-baseline](#create-baseline). You can now reference the baseline file in your configuration, as below.
-
 ```xml
 <build>
     <plugins>
@@ -187,7 +222,7 @@ This will generate a baseline file for each module named as `baseline-<module-na
 </build>
 ```
 
-## Using Type Resolution
+### Using Type Resolution
 
 See [Issue #144](https://github.com/Ozsie/detekt-maven-plugin/issues/144) for an explanation.
 
@@ -230,8 +265,8 @@ See [Issue #144](https://github.com/Ozsie/detekt-maven-plugin/issues/144) for an
 </build>
 ```
 
-### Goals
-#### check
+## Goals
+### `check`
 
 Used to run detekt. All cli parameters, excluding -gc and -cb, are available using -Ddetekt.{parameter}
 
@@ -245,7 +280,7 @@ If you need type resolution, use the following instead
  * `mvn detekt:ctr -Ddetekt.config=detekt.yml`
  * `mvn detekt:ctr -Ddetekt.debug=true`
 
-#### create-baseline
+### `create-baseline`
 
 Used to create a baseline. All cli parameters, excluding -gc and -cb,
 are available using -Ddetekt.{parameter}. By default, a file called
@@ -260,7 +295,7 @@ _Examples_
 *  `mvn detekt:create-baseline -Ddetekt.config=detekt.yml`
  * `mvn detekt:create-baseline -Ddetekt.debug=true`
 
-#### generate-config
+### `generate-config`
 
 Used to generate a default configuration file
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # Detekt Maven Plugin
 
 A [Maven](https://maven.apache.org) [plugin](https://maven.apache.org/plugins/index.html) that wraps the [Detekt](https://detekt.dev/) CLI. It supports the same parameters as the [Detekt CLI](https://detekt.dev/docs/gettingstarted/cli).
- 
+
 ## How to use
 See [below](#goals) how to execute after configuring.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 # Detekt Maven Plugin
 
-A maven plugin that wraps the Detekt CLI. It supports the same parameters as the Detekt CLI.
-
+A [Maven](https://maven.apache.org) [plugin](https://maven.apache.org/plugins/index.html) that wraps the [Detekt](https://detekt.dev/) CLI. It supports the same parameters as the [Detekt CLI](https://detekt.dev/docs/gettingstarted/cli).
+ 
 ## How to use
 See [below](#goals) how to execute after configuring.
 
@@ -85,10 +85,10 @@ The plugin supports remote config over http and https.
 </build>
 ```
 
-### Using extensions
+### Extensions
 Detekt supports [rulesets, processors, reports, etc.](https://detekt.dev/docs/introduction/extensions) packaged in Detekt plugins.
 
-#### Using published Detekt plugins
+#### Published Detekt plugins
 See [Detekt Marketplace](https://detekt.dev/marketplace) for list of known plugins.
 
 ```xml
@@ -222,7 +222,7 @@ This will generate a baseline file for each module named as `baseline-<module-na
 </build>
 ```
 
-### Using Type Resolution
+### Type Resolution
 
 See [Issue #144](https://github.com/Ozsie/detekt-maven-plugin/issues/144) for an explanation.
 
@@ -297,15 +297,13 @@ _Examples_
 
 ### `generate-config`
 
-Used to generate a default configuration file
+Used to generate a default configuration file.
 
 _Example_
 
  * `mvn detekt:gc`
  * `mvn detekt:generate-config`
- 
- For more information on Detekt, have a look at https://github.com/detekt/detekt
- 
+
 ## Contributors
 <a href="https://github.com/detekt/detekt/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=ozsie/detekt-maven-plugin" />


### PR DESCRIPTION
## Changes
 * Restructured hierarchy a bit so nesting is cleaner.
 * Revised headers for clarity (minimize wording, remove redundant words, use Detekt terminology)
 * Added local rule configuration as the first config, as most of the users will configure via local detekt.yml, not a remote URL.
 * Added real example of plugin usage
 * Moved "local Detekt plugins" section lower down, as it's more likely people will use plugins from Maven repos.
 * Added links to Detekt docs for easy access.

## Visual
For testing, preview is available at [this PR's branch HEAD](https://github.com/TWiStErRob/detekt-maven-plugin/tree/patch-1).

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/2906988/210802237-81e33a56-0cac-4722-8f65-6ff77a603d53.png) | ![image](https://user-images.githubusercontent.com/2906988/210803900-a18ca838-51e8-42d0-af79-1b19eb7b01e7.png) |


## Admin

Feel free to squash these commits on merge.