### PR TITLE
Add support for multiple input directories

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -3,8 +3,10 @@
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>InvalidPackageDeclaration:ValidFile.kt$package `code-samples`.`valid`</ID>
+    <ID>InvalidPackageDeclaration:ValidFile2.kt$package `code-samples`.valid2</ID>
     <ID>InvalidPackageDeclaration:WildcardImportViolated.kt$package `code-samples`.`invalid-package-naming`</ID>
     <ID>PackageNaming:ValidFile.kt$package `code-samples`.`valid`</ID>
+    <ID>PackageNaming:ValidFile2.kt$package `code-samples`.valid2</ID>
     <ID>PackageNaming:WildcardImportViolated.kt$package `code-samples`.`invalid-package-naming`</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/src/test/resources/code-samples/valid2/ValidFile2.kt
+++ b/src/test/resources/code-samples/valid2/ValidFile2.kt
@@ -1,0 +1,1 @@
+package `code-samples`.valid2


### PR DESCRIPTION
The detekt CLI docs indicate that multiple input directories can be supplied to it, using the -i/--input switch, provided they're delimited by commas. I've recently written a git hook which I'd like to use in conjunction with the detekt maven plugin so that only modified files are scanned by detekt. This will dramatically decrease the time it takes for pre-commit checks to happen, as the code base I'm working with is particularly large and scanning all files is a lengthy operation.

The changes here enable multiple directories to be provided. Each in turn is verified before being passed through to detekt. If any directories can't be resolved, the process is aborted and the offending paths are logged to standard out.