### PR TITLE
Allow for file paths on the input argument (not only directories)

### DIFF
--- a/src/main/java/com/github/ozsie/CheckMojo.kt
+++ b/src/main/java/com/github/ozsie/CheckMojo.kt
@@ -20,13 +20,14 @@ class CheckMojo : DetektMojo() {
             log.debug("Applying $it")
         }
         val cliArgs = parseArguments(getCliSting().log().toTypedArray())
-        val invalidInputDirs = input.split(",").mapNotNull {
-            if (!Files.isDirectory(Paths.get(it))) it else null
+        val invalidInputs = input.split(",").filter {
+            val path = Paths.get(it)
+            !Files.isDirectory(Paths.get(it)) && !Files.exists(path)
         }
-        if (!skip && invalidInputDirs.isEmpty())
+        if (!skip && invalidInputs.isEmpty())
             failBuildIfNeeded { Runner(cliArgs, System.out, System.err).execute() }
         else
-            inputSkipLog(skip, invalidInputDirs)
+            inputSkipLog(skip, invalidInputs)
     }
 
     private fun failBuildIfNeeded(block: () -> Unit) {


### PR DESCRIPTION
The [detekt-cli](https://detekt.dev/docs/gettingstarted/cli/#use-the-cli) allows for a comma-separated list of paths - including single files - to run the checks on.

This PR makes sure we can also use this feature with this plugin.

Following up on: https://github.com/Ozsie/detekt-maven-plugin/pull/203 where multiple directories were supported, however, the detekt-cli not only accepts directories, but single file(s) too. 🚀 